### PR TITLE
Corrects README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ interface Logger {
 ### Example
 
 ```js
-const feeds = new Feeds({ serviceId: your_service_id });
+const feeds = new Feeds({ instanceId: your_instance_id });
 ```
 
 ## Get a reference to a feed


### PR DESCRIPTION
According to the Getting Started guide on `dash.pusher.com/feeds` the feeds constructor accepts an object with the key `instanceId` not `serviceId` as demonstrated in this README.